### PR TITLE
Add fly_trade_trades to aggregator sources

### DIFF
--- a/dbt_subprojects/dex/models/aggregator_trades/dex_aggregator_trades.sql
+++ b/dbt_subprojects/dex/models/aggregator_trades/dex_aggregator_trades.sql
@@ -24,6 +24,7 @@
     ,ref('oneinch_ar_trades')
     ,ref('odos_trades')
     ,ref('sushiswap_agg_trades')
+    ,ref('fly_trade_trades')
 ] %}
 
 WITH enriched_aggregator_base_trades AS (


### PR DESCRIPTION
Included the fly_trade_trades model in the list of referenced aggregator trade sources in dex_aggregator_trades.sql to ensure its data is incorporated into the aggregation.

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
