### PR TITLE
Remove commented UNION ALL from taiko trades SQL

### DIFF
--- a/dbt_subprojects/dex/models/_projects/fly_trade/taiko/fly_trade_aggregator_taiko_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/taiko/fly_trade_aggregator_taiko_trades.sql
@@ -19,7 +19,6 @@
 WITH swaps AS (
     
     -- Version V3
-    -- UNION ALL
     SELECT
         '{{ network }}' AS blockchain
         ,'fly_trade' AS project


### PR DESCRIPTION
Cleaned up the fly_trade_aggregator_taiko_trades.sql file by removing an unused commented-out UNION ALL statement in the swaps CTE. This improves code readability.

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
