### PR TITLE
Deduplicate trades using ROW_NUMBER in fly_trade aggregators

### DIFF
--- a/dbt_subprojects/dex/models/_projects/fly_trade/arbitrum/fly_trade_aggregator_arbitrum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/arbitrum/fly_trade_aggregator_arbitrum_trades.sql
@@ -36,7 +36,8 @@ WITH swaps AS (
         ,evt_tx_from AS tx_from
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
-        ,ARRAY[-1] AS trace_address
+        ,ARRAY[-1] AS trace_address,
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_beta_multichain', 'MulticallFacet_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -65,6 +66,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV2Arbitrum_evt_Swap') }}
     {% if is_incremental() %}
@@ -92,6 +94,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV21Arbitrum_evt_Swap') }}
     {% if is_incremental() %}
@@ -119,6 +122,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
    
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
@@ -148,6 +152,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -222,3 +227,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/avalanche_c/fly_trade_aggregator_avalanche_c_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/avalanche_c/fly_trade_aggregator_avalanche_c_trades.sql
@@ -37,6 +37,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_beta_multichain', 'DiamondCutFacet_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -65,6 +66,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV2Avalanche_evt_Swap') }}
     {% if is_incremental() %}
@@ -92,6 +94,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV21Avalanche_evt_Swap') }}
     {% if is_incremental() %}
@@ -119,6 +122,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -147,6 +151,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -221,3 +226,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/base/fly_trade_aggregator_base_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/base/fly_trade_aggregator_base_trades.sql
@@ -37,6 +37,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_aggregator_base', 'Diamond_evt_Swap') }}
     {% if is_incremental() %}
@@ -64,6 +65,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV2Base_evt_Swap') }}
     {% if is_incremental() %}
@@ -91,6 +93,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV21Base_evt_Swap') }}
     {% if is_incremental() %}
@@ -118,6 +121,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -146,6 +150,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -220,3 +225,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/berachain/fly_trade_aggregator_berachain_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/berachain/fly_trade_aggregator_berachain_trades.sql
@@ -37,6 +37,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -65,6 +66,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -139,3 +141,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/blast/fly_trade_aggregator_blast_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/blast/fly_trade_aggregator_blast_trades.sql
@@ -38,6 +38,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -66,6 +67,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -140,3 +142,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/bnb/fly_trade_aggregator_bnb_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/bnb/fly_trade_aggregator_bnb_trades.sql
@@ -37,6 +37,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_beta_multichain', 'AggregatorFacet_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -65,6 +66,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV2BSC_evt_Swap') }}
     {% if is_incremental() %}
@@ -92,6 +94,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV21BSC_evt_Swap') }}
     {% if is_incremental() %}
@@ -119,6 +122,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
     
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
@@ -148,6 +152,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -222,3 +227,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/ethereum/fly_trade_aggregator_ethereum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/ethereum/fly_trade_aggregator_ethereum_trades.sql
@@ -37,6 +37,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_beta_multichain', 'AggregatorFacet_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -65,6 +66,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV2Ethereum_evt_Swap') }}
     {% if is_incremental() %}
@@ -92,6 +94,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV21Ethereum_evt_Swap') }}
     {% if is_incremental() %}
@@ -119,6 +122,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -147,6 +151,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -221,3 +226,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/linea/fly_trade_aggregator_linea_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/linea/fly_trade_aggregator_linea_trades.sql
@@ -39,6 +39,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
     
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
@@ -68,6 +69,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -142,3 +144,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/optimism/fly_trade_aggregator_optimism_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/optimism/fly_trade_aggregator_optimism_trades.sql
@@ -37,6 +37,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_beta_multichain', 'DiamondCutFacet_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -65,6 +66,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV2Optimism_evt_Swap') }}
     {% if is_incremental() %}
@@ -92,6 +94,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV21Optimism_evt_Swap') }}
     {% if is_incremental() %}
@@ -119,6 +122,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
     
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
@@ -148,6 +152,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -222,3 +227,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/polygon/fly_trade_aggregator_polygon_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/polygon/fly_trade_aggregator_polygon_trades.sql
@@ -37,6 +37,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_beta_multichain', 'MulticallFacet_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -65,6 +66,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV2Polygon_evt_Swap') }}
     {% if is_incremental() %}
@@ -92,6 +94,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV21Polygon_evt_Swap') }}
     {% if is_incremental() %}
@@ -119,6 +122,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
     
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
@@ -148,6 +152,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -222,3 +227,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/scroll/fly_trade_aggregator_scroll_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/scroll/fly_trade_aggregator_scroll_trades.sql
@@ -38,6 +38,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV21Scroll_evt_Swap') }}
     {% if is_incremental() %}
@@ -65,6 +66,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -93,6 +95,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -167,3 +170,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/taiko/fly_trade_aggregator_taiko_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/taiko/fly_trade_aggregator_taiko_trades.sql
@@ -38,6 +38,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -66,6 +67,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_multichain', 'MagpieRouterV3_1_evt_Swap') }}
     WHERE chain = '{{ network }}'
@@ -140,3 +142,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1

--- a/dbt_subprojects/dex/models/_projects/fly_trade/zksync/fly_trade_aggregator_zksync_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/zksync/fly_trade_aggregator_zksync_trades.sql
@@ -37,6 +37,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV2zkSync_evt_Swap') }}
     {% if is_incremental() %}
@@ -64,6 +65,7 @@ WITH swaps AS (
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
         ,ARRAY[-1] AS trace_address
+        ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_protocol_' ~ network, 'MagpieRouterV21zkSync_evt_Swap') }}
     {% if is_incremental() %}
@@ -137,3 +139,4 @@ LEFT JOIN {{ source('prices', 'usd') }} p_eth
     {% else %}
     AND p_eth.minute >= TIMESTAMP '{{ project_start_date }}'
     {% endif %}
+WHERE swaps.rn = 1


### PR DESCRIPTION
Added ROW_NUMBER() partitioned by evt_tx_hash and filtered to keep only the latest swap per transaction across all fly_trade aggregator models. This ensures deduplication of trades and more accurate trade aggregation for all supported networks.

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
