### PR TITLE
Remove trailing comma in SELECT statement

### DIFF
--- a/dbt_subprojects/dex/models/_projects/fly_trade/arbitrum/fly_trade_aggregator_arbitrum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/arbitrum/fly_trade_aggregator_arbitrum_trades.sql
@@ -36,7 +36,7 @@ WITH swaps AS (
         ,evt_tx_from AS tx_from
         ,evt_tx_to AS tx_to
         ,evt_index AS evt_index
-        ,ARRAY[-1] AS trace_address,
+        ,ARRAY[-1] AS trace_address
         ,ROW_NUMBER() OVER (PARTITION BY evt_tx_hash ORDER BY evt_block_time DESC) AS rn
     FROM
         {{ source('magpie_beta_multichain', 'MulticallFacet_evt_Swap') }}


### PR DESCRIPTION
Eliminated an unnecessary trailing comma after the trace_address field in the SELECT statement to ensure SQL syntax correctness.

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
