### PR TITLE
Update Fly Trade aggregator version to v21

### DIFF
--- a/dbt_subprojects/dex/models/_projects/fly_trade/arbitrum/fly_trade_aggregator_arbitrum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/arbitrum/fly_trade_aggregator_arbitrum_trades.sql
@@ -78,7 +78,7 @@ WITH swaps AS (
     SELECT
         '{{ network }}' AS blockchain
         ,'fly_trade' AS project
-        ,'v2' AS version
+        ,'v21' AS version
         ,CAST(date_trunc('day', evt_block_time) AS DATE) AS block_date
         ,CAST(date_trunc('month', evt_block_time) AS DATE) AS block_month
         ,evt_block_time AS block_time

--- a/dbt_subprojects/dex/models/_projects/fly_trade/avalanche_c/fly_trade_aggregator_avalanche_c_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/avalanche_c/fly_trade_aggregator_avalanche_c_trades.sql
@@ -78,7 +78,7 @@ WITH swaps AS (
     SELECT
         '{{ network }}' AS blockchain
         ,'fly_trade' AS project
-        ,'v2' AS version
+        ,'v21' AS version
         ,CAST(date_trunc('day', evt_block_time) AS DATE) AS block_date
         ,CAST(date_trunc('month', evt_block_time) AS DATE) AS block_month
         ,evt_block_time AS block_time

--- a/dbt_subprojects/dex/models/_projects/fly_trade/base/fly_trade_aggregator_base_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/base/fly_trade_aggregator_base_trades.sql
@@ -77,7 +77,7 @@ WITH swaps AS (
     SELECT
         '{{ network }}' AS blockchain
         ,'fly_trade' AS project
-        ,'v2' AS version
+        ,'v21' AS version
         ,CAST(date_trunc('day', evt_block_time) AS DATE) AS block_date
         ,CAST(date_trunc('month', evt_block_time) AS DATE) AS block_month
         ,evt_block_time AS block_time

--- a/dbt_subprojects/dex/models/_projects/fly_trade/bnb/fly_trade_aggregator_bnb_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/bnb/fly_trade_aggregator_bnb_trades.sql
@@ -78,7 +78,7 @@ WITH swaps AS (
     SELECT
         '{{ network }}' AS blockchain
         ,'fly_trade' AS project
-        ,'v2' AS version
+        ,'v21' AS version
         ,CAST(date_trunc('day', evt_block_time) AS DATE) AS block_date
         ,CAST(date_trunc('month', evt_block_time) AS DATE) AS block_month
         ,evt_block_time AS block_time

--- a/dbt_subprojects/dex/models/_projects/fly_trade/ethereum/fly_trade_aggregator_ethereum_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/ethereum/fly_trade_aggregator_ethereum_trades.sql
@@ -78,7 +78,7 @@ WITH swaps AS (
     SELECT
         '{{ network }}' AS blockchain
         ,'fly_trade' AS project
-        ,'v2' AS version
+        ,'v21' AS version
         ,CAST(date_trunc('day', evt_block_time) AS DATE) AS block_date
         ,CAST(date_trunc('month', evt_block_time) AS DATE) AS block_month
         ,evt_block_time AS block_time

--- a/dbt_subprojects/dex/models/_projects/fly_trade/optimism/fly_trade_aggregator_optimism_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/optimism/fly_trade_aggregator_optimism_trades.sql
@@ -78,7 +78,7 @@ WITH swaps AS (
     SELECT
         '{{ network }}' AS blockchain
         ,'fly_trade' AS project
-        ,'v2' AS version
+        ,'v21' AS version
         ,CAST(date_trunc('day', evt_block_time) AS DATE) AS block_date
         ,CAST(date_trunc('month', evt_block_time) AS DATE) AS block_month
         ,evt_block_time AS block_time

--- a/dbt_subprojects/dex/models/_projects/fly_trade/polygon/fly_trade_aggregator_polygon_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/polygon/fly_trade_aggregator_polygon_trades.sql
@@ -78,7 +78,7 @@ WITH swaps AS (
     SELECT
         '{{ network }}' AS blockchain
         ,'fly_trade' AS project
-        ,'v2' AS version
+        ,'v21' AS version
         ,CAST(date_trunc('day', evt_block_time) AS DATE) AS block_date
         ,CAST(date_trunc('month', evt_block_time) AS DATE) AS block_month
         ,evt_block_time AS block_time

--- a/dbt_subprojects/dex/models/_projects/fly_trade/scroll/fly_trade_aggregator_scroll_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/scroll/fly_trade_aggregator_scroll_trades.sql
@@ -22,7 +22,7 @@ WITH swaps AS (
     SELECT
         '{{ network }}' AS blockchain
         ,'fly_trade' AS project
-        ,'v2' AS version
+        ,'v21' AS version
         ,CAST(date_trunc('day', evt_block_time) AS DATE) AS block_date
         ,CAST(date_trunc('month', evt_block_time) AS DATE) AS block_month
         ,evt_block_time AS block_time

--- a/dbt_subprojects/dex/models/_projects/fly_trade/zksync/fly_trade_aggregator_zksync_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/zksync/fly_trade_aggregator_zksync_trades.sql
@@ -49,7 +49,7 @@ WITH swaps AS (
     SELECT
         '{{ network }}' AS blockchain
         ,'fly_trade' AS project
-        ,'v2' AS version
+        ,'v21' AS version
         ,CAST(date_trunc('day', evt_block_time) AS DATE) AS block_date
         ,CAST(date_trunc('month', evt_block_time) AS DATE) AS block_month
         ,evt_block_time AS block_time


### PR DESCRIPTION
Changed the 'version' field from 'v2' to 'v21' in Fly Trade aggregator trade models across all supported networks. This ensures consistency and reflects the latest versioning for Fly Trade data aggregation.

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
