### PR TITLE
Update Fly Trade and aggregator trade model references

### DIFF
--- a/dbt_subprojects/dex/models/_projects/fly_trade/fly_trade_trades.sql
+++ b/dbt_subprojects/dex/models/_projects/fly_trade/fly_trade_trades.sql
@@ -13,7 +13,18 @@
 
 {% set models = [
     ref('fly_trade_aggregator_arbitrum_trades')
-
+    ,ref('fly_trade_aggregator_avalanche_c_trades')
+    ,ref('fly_trade_aggregator_ethereum_trades')
+    ,ref('fly_trade_aggregator_optimism_trades')
+    ,ref('fly_trade_aggregator_bnb_trades')
+    ,ref('fly_trade_aggregator_polygon_trades')
+    ,ref('fly_trade_aggregator_scroll_trades')
+    ,ref('fly_trade_aggregator_blast_trades')
+    ,ref('fly_trade_aggregator_zksync_trades')
+    ,ref('fly_trade_aggregator_taiko_trades')
+    ,ref('fly_trade_aggregator_linea_trades')
+    ,ref('fly_trade_aggregator_berachain_trades')
+    ,ref('fly_trade_aggregator_base_trades')
 ] %}
 
 

--- a/dbt_subprojects/dex/models/aggregator_trades/dex_aggregator_trades.sql
+++ b/dbt_subprojects/dex/models/aggregator_trades/dex_aggregator_trades.sql
@@ -24,7 +24,6 @@
     ,ref('oneinch_ar_trades')
     ,ref('odos_trades')
     ,ref('sushiswap_agg_trades')
-    ,ref('fly_trade_trades')
 ] %}
 
 WITH enriched_aggregator_base_trades AS (


### PR DESCRIPTION
Added multiple chain-specific Fly Trade aggregator models to fly_trade_trades.sql and removed fly_trade_trades reference from dex_aggregator_trades.sql. This change improves modularity and ensures each chain's trades are handled separately.

## Thank you for contributing to Spellbook 🪄
Please open the PR in **draft** and mark as ready when you want to request a review. 

### Description:

[...]


---
quick links for more information:
- [README.md](https://github.com/duneanalytics/spellbook/blob/main/README.md)
- [spellbook docs](https://github.com/duneanalytics/spellbook/tree/main/docs)
- [CONTRIBUTING.md](https://github.com/duneanalytics/spellbook/blob/main/CONTRIBUTING.md)
